### PR TITLE
vrepl: ignore hidden files (eg .swp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cake
 pom.xml
 *.jar
+*.sw[po]
 *.war
 .lein-deps-sum
 .DS_Store

--- a/vrepl/src/vrepl/core.clj
+++ b/vrepl/src/vrepl/core.clj
@@ -15,12 +15,15 @@
 
 
 (defn reload! [vfs-filename]
-  (let [path (.getPath vfs-filename)]
-    (println "Reloading:" path)
-    (case (.getExtension vfs-filename)
-      "clj"  (output-clj! (load-file path))
-      "cljs" "CLJS not implemented yet"
-      (println "I have no idea what to do with" path))))
+  (when-not (-> vfs-filename
+              .getBaseName
+              (.startsWith "."))
+    (let [path (.getPath vfs-filename)]
+      (println "Reloading:" path)
+      (case (.getExtension vfs-filename)
+        "clj"  (output-clj! (load-file path))
+        "cljs" "CLJS not implemented yet"
+        (println "I have no idea what to do with" path)))))
 
 (defn monitor-files! [path]
   (let [fm (DefaultFileMonitor. (reify FileListener


### PR DESCRIPTION
Ignore changes to dot files.  I noticed this when editing /sample files with vim, which modifies swp files while editing.
