### PR TITLE
svg:path support with lines (ala d3.svg.line)

### DIFF
--- a/src/cljx/c2/svg.cljx
+++ b/src/cljx/c2/svg.cljx
@@ -130,6 +130,13 @@
      ]))
 
 
+(defn line
+  "Return a Hiccup path SVG element with the [x,y] coordinates in the points sequence connected by lines"
+  [points]
+  (let [[[x y] & xs] points]
+    [:path {:d (apply str "M" x "," y
+                           (for [[x y] xs] (str "L" x "," y)))}]))
+
 (def ArcMax (- Tau 0.0000001))
 
 (defn circle

--- a/test/c2/t_svg.clj
+++ b/test/c2/t_svg.clj
@@ -1,0 +1,10 @@
+(ns c2.t-svg
+  (:use midje.sweet
+        [c2.svg :only [line]]))
+
+(tabular
+  (facts "Lines"
+        (line ?coords) => ?expected)
+  ?coords               ?expected
+  [[0,0] [1,1] [5,5]]   [:path {:d "M0,0L1,1L5,5"}])
+


### PR DESCRIPTION
Let me know if this should go in c2/geom/line instead.
