### PR TITLE
Fix for svg scale to correctly handle x,y coordinate inputs

### DIFF
--- a/src/cljx/c2/svg.cljx
+++ b/src/cljx/c2/svg.cljx
@@ -27,10 +27,10 @@
     (str "translate(" (float x) "," (float y) ")")))
 
 (defn scale [coordinates]
-  (cond
-   (number? coordinates) (str "scale(" (float coordinates) ")")
-   (map? coordinates) [(:x coordinates) (:y coordinates)]
-   (and (vector? coordinates) (= 2 (count count))) coordinates))
+  (if (number? coordinates)
+    (str "scale(" (float coordinates) ")")
+    (let [[x y] (svg/->xy coordinates)]
+      (str "scale(" (float x) "," (float y) ")"))))
 
 (defn rotate
   ([angle] (rotate angle [0 0]))


### PR DESCRIPTION
svg/scale did not actually create a SVG `scale` command for x,y coordinate input and had a typo in the vector detection line. The latest Clojurescript catches this error. The fix handles all cases uses the existing `->xy` function.
