### PR TITLE
Colors on sunburst example are broken

### DIFF
--- a/vrepl/resources/samples/sunburst.clj
+++ b/vrepl/resources/samples/sunburst.clj
@@ -4,19 +4,19 @@
         [c2.maths :only [sqrt sin cos Tau]] ;;Life's short, don't waste it writing 2*Pi
         [c2.svg :only [arc]]
         [c2.layout.partition :only [partition]]
-        
+
         [vomnibus.d3 :only [flare]]
         [vomnibus.d3-color :only [Categorical-20]]))
 
 (let [radius 270
       ;;Partition will give us entries for every node;
       ;;we only want slices, so filter out the root node.
-      slices (filter #(-> % :partition :depth (not= 0)) 
+      slices (filter #(-> % :partition :depth (not= 0))
                      (partition flare :value :size
                                 :size [Tau (* radius radius)]))
       ;;TODO: Rework partition to include reference to parent so we can match D3's coloring scheme?
       color-scale (apply hash-map (interleave
-                                   (into #{} (map :name (filter :children slices)))
+                                   (into #{} (map #(keyword (:name %)) slices))
                                    (flatten (repeat Categorical-20))))]
 
   [:svg {:width (* 2 radius) :height (* 2 radius)}
@@ -30,5 +30,5 @@
                         :outer-radius (sqrt (+ y dy))
                         :start-angle x
                         :end-angle  (+ x dx))
-                :fill "white"}]]))]]
+                :fill ((keyword name) color-scale)}]]))]]
 )


### PR DESCRIPTION
The sunburst example does not use the previously defined color-scale but just uses hardcoded "white"
